### PR TITLE
Fix TransformersModelManager: Prevents crash by dispatching model on all GPUs

### DIFF
--- a/lib/TransformersModelManager.py
+++ b/lib/TransformersModelManager.py
@@ -8,6 +8,7 @@ from lib.config import MODELS_FOLDER, TRANSFORMERS_INFERENCE_MAX_TOKENS, TRANSFO
 from transformers import LogitsProcessor
 import torch
 import time
+import gc
 
 from transformers import (
     TemperatureLogitsWarper,


### PR DESCRIPTION
Enable multi GPU usage in swicth_model function. Free memory properly in clear_model function


